### PR TITLE
Fix for Chapter Report transmit bug

### DIFF
--- a/app/controllers/ReportController.php
+++ b/app/controllers/ReportController.php
@@ -395,14 +395,16 @@ class ReportController extends \BaseController
 
         foreach ($chapter->getChapterIdWithParents() as $chapterId) {
             $tmpChapter = Chapter::find($chapterId);
-
+            
             if (in_array(
                     $tmpChapter->chapter_type,
                     ['ship', 'division', 'squadron', 'task_group', 'task_force', 'fleet', 'station']
                 ) === true
             ) {
                 if ($chapter->id != $tmpChapter->id) {
+                    if (empty($tmpChapter->getCO()) === false) {
                     $echelonEmails[] = $tmpChapter->getCO()->email_address;
+                    }   
                 }
             }
         }


### PR DESCRIPTION
Fix for bug #69 involving chapters which have an echelon in the Chain of Command without a CO defined.  Adds error checking to ensure that the CO of the echelon to be added to the CC list exists.