### PR TITLE
Hotfix/highest exam

### DIFF
--- a/resources/views/errors/user-not-found.blade.php
+++ b/resources/views/errors/user-not-found.blade.php
@@ -1,45 +1,68 @@
 <!DOCTYPE html>
 <html>
 <head>
-
     <title>User or Chapter not found | Royal Manticoran Navy Database</title>
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/normalize.min.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/foundation.min.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/jquery.ui.datepicker.min.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/jquery.dataTables.min.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/dataTables.foundation.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/dataTables.jqueryui.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/jquery-ui.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/selectize.css') !!}">
-    <link rel="stylesheet" type="text/css" href="{!! asset('css/main.css') !!}">
+    <META HTTP-EQUIV="cache-control" CONTENT="no-cache">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.16/sc-1.4.3/datatables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="{!! asset('css/vendor.css') !!}?{{ time() }}">
+    <link rel="stylesheet" type="text/css" href="{!! asset('css/app.css') !!}?{{ time() }}">
+    <link rel="stylesheet" type="text/css" href="{!! asset('css/overrides.css') !!}?{{ time() }}">
+    <link href="https://fonts.googleapis.com/css?family=Volkhov" rel="stylesheet">
+
     <link rel="shortcut icon" href="{!! asset('favicon.ico') !!}">
+    @yield('dochead')
 </head>
 <body>
-<div class="container">
-    <header class="row trmn-width">
-
-        <div class="col-sm-2  trmn-width">
-            <p></p><a href="{!!$serverUrl!!}"><img src="/images/trmn-seal.png" alt="TRMN Seal" width="150px"
-                                                   height="150px"></a>
-        </div>
-        <div class="col-sm-10  trmn-width ">
+<div class="container-fluid">
+    <div class="row inset-bottom flex-vert-center navbar-fixed-top black-background header">
+        <div class="col-sm-4 text-nowrap">
             <h1 class="trmn">The Royal<br/>Manticoran Navy</h1>
-
-            <h3 class="trmn">Membership Database</h3>
         </div>
-    </header>
-    <div class="row trmn-width">
-        <div class="col-sm-12  trmn-width">
-            <h2>I'm dreadfully sorry, Your Grace, but it simply won't be possible.</h2>
-
-            <p>The officers you requested are currently unavailable for assignment at this time.</p>
 
 
-            <p class="text-center"><strong>Ok, ok. We couldn't find the member or chapter you were looking for....</strong></p>
+        <div class="col-sm-4 text-center">
+            <h3 class="trmn roster-narrow-1160 roster-narrow-1045">Membership Database</h3>
+        </div>
+
+        <div class="col-sm-4 text-right text-nowrap">
+            @if(Auth::check())
+                <a href="/home" title="Return to your Service Record">
+                    <strong>{{ Auth::user()->getGreeting() }}
+                        {{ substr(Auth::user()->first_name, 0, 1) }}
+                        .{{ strlen(Auth::user()->middle_name) ? ' ' . substr(Auth::user()->middle_name, 0, 1) . '. ' : ' ' }} {{ Auth::user()->last_name }}</strong></a>
+                <h5 class="Incised901Light ninety">Last
+                    Login: {!!date('d M Y @ g:i A T', strtotime(Auth::user()->getLastLogin()))!!}</h5>
+
+                <h5 class="Incised901Light ninety"><span class="fa fa-exclamation-triangle yellow" data-toggle="tooltip" data-placement="bottom" title="Accuracy is effected by the use of 'Remember Me' when logging in to the Forums"></span>&nbsp;Last Forum
+                    Login:
+                    @if(Auth::user()->forum_last_login)
+                        {{date('d M Y @ g:i A T', Auth::user()->forum_last_login)}}
+                    @else
+                        Never
+                    @endif
+                </h5>
+            @endif
+        </div>
+
+    </div>
+
+    <div class="row ">
+        <div class="col-sm-12 text-center">
+            <div class="padding-top-10 padding-bottom-10 float-left">
+                <a href="{!!$serverUrl!!}"><img src="/images/trmn-seal.png" alt="TRMN Seal" width="150px"
+                                                height="150px"></a>
+            </div>
+            <h2>&ldquo;I'm dreadfully sorry, Your Grace, but it simply won't be possible.</h2>
+
+            <h3>The officers you requested are currently unavailable for assignment at this time.&rdquo;</h3>
+            <p>&nbsp;</p>
+
+            <p class="text-center"><strong>Ok, ok. We couldn't find the member or chapter you were looking for... </strong></p>
+            <p><a href="/home" class="btn btn-lg btn-primary">Return to the main page</a></p>
         </div>
     </div>
 </div>
-<footer>
+<footer class="inset-top">
     <p>Copyright &copy; 2008 &ndash; {!! date('Y') !!} The Royal Manticoran Navy: The Official Honor Harrington Fan
         Association,
         Inc. Some Rights Reserved.
@@ -47,35 +70,21 @@
     <span class="text-center"><img src="{!!asset('images/project-medusa.svg')!!}" width="150px" height="150px"
                                    data-src="{!!asset('images/project-medusa.svg')!!}"></span>
     <p>{!! Config::get('app.version') !!}</p>
-    @if($_SERVER['SERVER_NAME'] == "medusa.dev" || $_SERVER['SERVER_NAME'] == "medusa-dev.trmn.org")
-        <p class="alert">
-            @if($_SERVER['SERVER_NAME'] == "medusa.dev")
-                LOCAL SANDBOX SERVER
-            @else
+    @if(in_array($_SERVER['SERVER_NAME'],  ["medusa.dev", "medusa-dev.trmn.org", "medusa.local", "localhost"]))
+        <div class="alert alert-info text-center alert-text">
+            @if($_SERVER['SERVER_NAME'] == "medusa-dev.trmn.org")
                 DEVELOPMENT / TEST SERVER
+            @else
+                LOCAL SANDBOX SERVER
             @endif
-        </p>
+        </div>
     @endif
     <span id="siteseal"><script type="text/javascript"
                                 src="https://seal.starfieldtech.com/getSeal?sealID=v0CA19iS5KO2zCDMQWVQcf848PG2A4U0OWBVbTgzfEuk6Lrf8ASy84CTVQ5M"></script></span>
 </footer>
+<script type="text/javascript" src="{!! asset('js/vendor.js')!!}?{{ time() }}"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.16/sc-1.4.3/datatables.min.js"></script>
 
-<script type="text/javascript" src="{!! asset('js/jquery.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/foundation.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/foundation.topbar.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/foundation.accordion.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/foundation.reveal.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/jquery-ui.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/jquery.dataTables.min.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/dataTables.foundation.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/dataTables.jqueryui.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/jquery.autocomplete.js')!!}"></script>
-<script type="text/javascript" src="{!! asset('js/selectize.min.js') !!}"></script>
-<script type="text/javascript" src="{!! asset('js/jquery.multipage.js') !!}"></script>
-<script type="text/javascript" src="{!! asset('js/js.cookie.js') !!}"></script>
-<script>
-    jQuery(document).foundation();
-</script>
-<script src="{!! asset('js/rcswitcher.js')!!}"></script>
-<script src="{!! asset('js/bundle.js')!!}"></script>
+<script src="{!! asset('js/app.js')!!}?{{ time() }}"></script>
+@yield( 'scriptFooter' )
 </body>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -157,6 +157,7 @@
                 </div>
         </div>
     </div>
+</div>
     <footer class="inset-top">
         <p>Copyright &copy; 2008 &ndash; {!! date('Y') !!} The Royal Manticoran Navy: The Official Honor Harrington Fan
             Association,

--- a/resources/views/partials/greeting.blade.php
+++ b/resources/views/partials/greeting.blade.php
@@ -1,6 +1,6 @@
 <div class="Incised901Bold">
     {!! $user->getGreeting() !!}
-    {!! $user->first_name !!}{{ isset($user->middle_name) ? ' ' . $user->middle_name : '' }} {!! $user->last_name !!}{{ !empty($user->suffix) ? ' ' . $user->suffix : '' }}{!!$user->getPostnominals()!!}, {!!$user->branch!!}
+    {!! $user->first_name !!}{{ isset($user->middle_name) ? ' ' . $user->middle_name : '' }} {!! $user->last_name !!}{{ !empty($user->suffix) ? ' ' . $user->suffix : '' }}{!!$user->getPostnominals()!!}, {!!$user->branch!!} @if($user->branch == 'CIVIL') ({{ $user->getRate() }}) @endif
 
     @if($permsObj->hasPermissions(['ID_CARD']) === true && empty($user->idcard_printed))
         <a class="fa fa-credit-card green size-24" href="/id/card/{!!$user->id!!}"


### PR DESCRIPTION
* Added new option 'except' to getExamList() 
* Added new method filterArrayInverse() to be used 'except' option
* Changed name of filterExams() method to filterArray() as it's really a generic regex filtering of an array by the key
* Added logic to better handle civilains in the getHighestMainLineExamForBranch() method
* Cleaned up html and css of the user not found template so it actually renders properly and added a "Return to the main page" button
* Added display of (DIPLOMATIC) and (INTEL) after CIVIL on service record
* Fixed unclosed div in the may layout template that is extended for pretty much every page
* Tightened up logic in processing options to getExamList()