### PR TITLE
fix for issue 218

### DIFF
--- a/app/Awards/AwardQualification.php
+++ b/app/Awards/AwardQualification.php
@@ -230,20 +230,17 @@ trait AwardQualification
                 }
         }
 
+        // Only process if the qualifications are defined,  it's a branch we check,
+        // and they don't have their specific E|O SWP
         if (is_null($swpQual) === false &&
             in_array($this->branch, $swpBranches) === true &&
             ($swpType === 'Enlisted' && $this->hasAward('ESWP') === false ||
             $swpType === 'Officer' && $this->hasAward('OSWP') === false)) {
-            // Only process if the qualifications are defined,  it's a branch we check,
-            // and they don't have their specific E|O SWP
-
 
             // Drill down to the specific branch and officer or enlisted
-
             $swpQual = $swpQual[$this->branch][$swpType];
 
             // Check for required
-
             $required = 0;
 
             foreach ($swpQual['Required'] as $exam) {

--- a/app/Awards/AwardQualification.php
+++ b/app/Awards/AwardQualification.php
@@ -233,7 +233,7 @@ trait AwardQualification
         if (is_null($swpQual) === false &&
             in_array($this->branch, $swpBranches) === true &&
             ($swpType === 'Enlisted' && $this->hasAward('ESWP') === false ||
-            $swpType === 'Officer' && $this->hasAward('OSWP') === false) ) {
+            $swpType === 'Officer' && $this->hasAward('OSWP') === false)) {
             // Only process if the qualifications are defined,  it's a branch we check,
             // and they don't have their specific E|O SWP
 

--- a/app/Awards/AwardQualification.php
+++ b/app/Awards/AwardQualification.php
@@ -210,31 +210,33 @@ trait AwardQualification
 
         $swpBranches = MedusaConfig::get('awards.swp.branches', ['RMN', 'RMMC']);
 
+        // Determine member's rank classification
+        $swpType = null;
+        switch (substr($this->rank['grade'], 0, 1)) {
+            case 'E':
+                $swpType = 'Enlisted';
+                break;
+            case 'W':
+            case 'O':
+            case 'F':
+            case 'M':
+                $swpType = 'Officer';
+                break;
+            case 'C':
+                if (substr($this->rank['grade'], 2) < 12) {
+                    $swpType = 'Enlisted';
+                } else {
+                    $swpType = 'Officer';
+                }
+        }
+
         if (is_null($swpQual) === false &&
             in_array($this->branch, $swpBranches) === true &&
-            $this->hasAward('ESWP') === false &&
-            $this->hasAward('OSWP') === false) {
-            // Only process if the qualifications are defined,  it's a branch we check and they don't have an E|O SWP
+            ($swpType === 'Enlisted' && $this->hasAward('ESWP') === false ||
+            $swpType === 'Officer' && $this->hasAward('OSWP') === false) ) {
+            // Only process if the qualifications are defined,  it's a branch we check,
+            // and they don't have their specific E|O SWP
 
-            $swpType = null;
-
-            switch (substr($this->rank['grade'], 0, 1)) {
-                case 'E':
-                    $swpType = 'Enlisted';
-                    break;
-                case 'W':
-                case 'O':
-                case 'F':
-                case 'M':
-                    $swpType = 'Officer';
-                    break;
-                case 'C':
-                    if (substr($this->rank['grade'], 2) < 12) {
-                        $swpType = 'Enlisted';
-                    } else {
-                        $swpType = 'Officer';
-                    }
-            }
 
             // Drill down to the specific branch and officer or enlisted
 


### PR DESCRIPTION
Lines 213-238 will be of interest. 
I changed the logic around: 
First I determine the person’s rank classification (Enlisted or Officer). 
Then I determine whether they’re eligible for consideration: 
If they’re Enlisted and they don’t have the ESWP 
or if they’re an Officer and don’t have the OSWP,
then the qualifications can be calculated.