### PR TITLE
Updating Awards Given/Requested

### DIFF
--- a/resources/views/report/chapter-create.blade.php
+++ b/resources/views/report/chapter-create.blade.php
@@ -338,7 +338,7 @@
 
     <div class="row form-group">
         <div class=" col-sm-3">
-            Awards Given/Requested:
+            Crew Accomplishments:
         </div>
         <div class=" col-sm-9">
             {!!Form::textarea('award_actions', null, ['class' => 'form-control'])!!}

--- a/resources/views/report/chapter-edit.blade.php
+++ b/resources/views/report/chapter-edit.blade.php
@@ -335,7 +335,7 @@
 
     <div class="row form-group">
         <div class=" col-sm-3">
-            Awards Given/Requested:
+            Crew Accomplishments:
         </div>
         <div class=" col-sm-9">
             {!!Form::textarea('award_actions', $report->award_actions, ['class' => 'form-control'])!!}

--- a/resources/views/report/chapter-email.blade.php
+++ b/resources/views/report/chapter-email.blade.php
@@ -95,7 +95,7 @@ Location: {!!$report->command_crew['Commanding Officer']['city']!!}, {!!$report-
 <br>
 REPORT INFORMATION<br><br>
 Promotions Awarded/Requested: @if(empty($report->promotion_actions) === false) {!!nl2br($report->promotion_actions)!!} @endif<br><br>
-Awards Given/Requested: @if(empty($report->award_actions) === false) {!!nl2br($report->award_actions)!!} @endif<br><br>
+Crew Accomplishments: @if(empty($report->award_actions) === false) {!!nl2br($report->award_actions)!!} @endif<br><br>
 Courses Completed: @if(empty($report->courses) === false) {!!nl2br($report->courses)!!} @endif<br><br>
 Chapter Activities, Last 60 Days: @if(empty($report->activities) === false) {!!nl2br($report->activities)!!} @endif<br><br>
 Problems: @if(empty($report->problems) === false) {!!nl2br($report->problems)!!} @endif<br><br>

--- a/resources/views/report/chapter-show.blade.php
+++ b/resources/views/report/chapter-show.blade.php
@@ -336,7 +336,7 @@
     <br/>
     <div class="row">
         <div class=" col-sm-3">
-            Awards Given/Requested:
+            Crew Accomplishments:
         </div>
         <div class=" col-sm-9">
             @if(empty($report->award_actions) === false)


### PR DESCRIPTION
By request of 1SL, it was deemed confusing on the ship reports to have Awards Given/Requested, as CO's thought this bypassed the normal awards process.  It has therefore been requested to change the title of this entry field to Crew Accomplishments