### PR TITLE
Fix a typo in 2025_05_08_154949_tt005562_align_pp_default.exams.php

### DIFF
--- a/database/migrations/2025_05_08_154949_tt005562_align_pp_default_exams.php
+++ b/database/migrations/2025_05_08_154949_tt005562_align_pp_default_exams.php
@@ -552,7 +552,7 @@ class Tt005562AlignPpDefaultExams extends Migration
         $oldpp = MedusaConfig::get('pp.requirements');
         MedusaConfig::set('pp.requirements.bak', $oldpp);
 
-        MedusaConfig::set('pp.requirememts', $newpp);
+        MedusaConfig::set('pp.requirements', $newpp);
     }
 
     /**


### PR DESCRIPTION
- Fix the typo where 'requirements' was typed as 'requirememts'.