### PR TITLE
Fix additional typos/errors in promotion requirements config entries

### DIFF
--- a/database/migrations/2025_02_16_121825_tt005211_update_rmacs_paygrades.php
+++ b/database/migrations/2025_02_16_121825_tt005211_update_rmacs_paygrades.php
@@ -35,7 +35,7 @@ class Tt005211UpdateRmacsPaygrades extends Migration
             'C-18' => 'Rear Admiral',
             'C-19' => 'Vice Admiral',
             'C-20' => 'Admiral',
-            'C-21' => 'Transport Minister',
+            'C-21' => 'Fleet Admiral',
             'C-22' => 'Home Secretary',
             'C-23' => null,
         ];

--- a/database/migrations/2025_05_08_154948_tt005562_align_pp_civil_exams.php
+++ b/database/migrations/2025_05_08_154948_tt005562_align_pp_civil_exams.php
@@ -364,7 +364,7 @@ class Tt005562AlignPpCivilExams extends Migration
             MedusaConfig::set('pp.requirements.'.$branch.'.bak', $oldpp);
 
             // Set the new requirements
-            MedusaConfig::set('pp.requirememts.'.$branch, $newpp);
+            MedusaConfig::set('pp.requirements.'.$branch, $newpp);
         }
     }
 

--- a/database/migrations/2025_06_06_111817_update_promotion_requirements.php
+++ b/database/migrations/2025_06_06_111817_update_promotion_requirements.php
@@ -180,9 +180,6 @@ class UpdatePromotionRequirements extends Migration
   "F-5": {
     "next": [ "F-6" ]
   },
-  "C-22": {
-    "next": [ "C-23" ]
-  },
   "F-5-A": {
     "next": [ "F-5-B" ]
   },


### PR DESCRIPTION
- Remove the next entry for C-22 => C-23 (non-existent)
- Another 'requirememts' typo. (Grr)