### PR TITLE
Add migration to set default for RMMM to Catering

### DIFF
--- a/database/migrations/2025_08_17_213443_fix_rmmm_default_rating.php
+++ b/database/migrations/2025_08_17_213443_fix_rmmm_default_rating.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\User;
+
+class FixRmmmDefaultRating extends Migration
+{
+    use App\Audit\MedusaAudit;
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $users = User::where('branch', 'RMMM')
+            ->where('registration_status', 'Active')
+            ->where(function ($query) {
+                $query->whereNull('rating')
+                      ->orWhere('rating', '');
+            })
+            ->get();
+
+        foreach ($users as $user) {
+
+
+            $user->rating = 'CATERING';
+
+            $history = $user->history;
+            $history[] = [
+                'timestamp' => time(),
+                'event' => 'Default rating set to CATERING for RMMM user',
+            ];
+            $user->history = $history;
+
+            $this->writeAuditTrail(
+                'system user',
+                'update',
+                'user',
+                null,
+                $user->toJson(),
+                'fix_rmmm_default_rating'
+            );
+
+            $user->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
- On users where RMMM members do not have a division specified, set it to Catering.