### PR TITLE
Update SWP report and create MCAM report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MEDUSA CHANGELOG
 
+## 2.1.3
+   - Added MCAM report (TT005608).
+   - Fixed missing end date for SWP report.
 ## 2.1.2
    - Added CSV export for exams with computed points based on the pp.exams
      regular expressions (TT005607).

--- a/app/Console/Commands/McamReport.php
+++ b/app/Console/Commands/McamReport.php
@@ -45,10 +45,10 @@ class McamReport extends Command
             $reportDate = date('Y-m-01');
         }
 
-        $endOfMonth = Carbon::parse($reportDate)->endOfMonth();
+        $endOfMonth = Carbon::parse($reportDate)->endOfMonth()->format('Y-m-d');
 
         $mcam['report_date'] = date('F, Y', strtotime($reportDate));
-        $mcam['MCAM'] = AwardLog::getAwardLogData(['award' => 'MCAM', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
+        $mcam['MCAM'] = AwardLog::getAwardLogData(['award' => 'MCAM', 'start' => $reportDate, 'end' => $endOfMonth]);
 
         \Mail::to(config('awards.SWP-notification.email'))->send(new \App\Mail\mcamReport($mcam));
     }

--- a/app/Console/Commands/McamReport.php
+++ b/app/Console/Commands/McamReport.php
@@ -3,23 +3,24 @@
 namespace App\Console\Commands;
 
 use App\AwardLog;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
-class SwpReport extends Command
+class McamReport extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'report:swp {date? : Month to run the report for in the format YYYY-MM}';
+    protected $signature = 'report:mcam {date? : Month to run the report for in the format YYYY-MM}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Generate and email SWP report';
+    protected $description = 'Generate and email MCAM report';
 
     /**
      * Create a new command instance.
@@ -46,10 +47,9 @@ class SwpReport extends Command
 
         $endOfMonth = Carbon::parse($reportDate)->endOfMonth();
 
-        $swp['report_date'] = date('F, Y', strtotime($reportDate));
-        $swp['ESWP'] = AwardLog::getAwardLogData(['award' => 'ESWP', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
-        $swp['OSWP'] = AwardLog::getAwardLogData(['award' => 'OSWP', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
+        $mcam['report_date'] = date('F, Y', strtotime($reportDate));
+        $mcam['MCAM'] = AwardLog::getAwardLogData(['award' => 'MCAM', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
 
-        \Mail::to(config('awards.SWP-notification.email'))->send(new \App\Mail\swpReport($swp));
+        \Mail::to(config('awards.SWP-notification.email'))->send(new \App\Mail\mcamReport($mcam));
     }
 }

--- a/app/Console/Commands/SwpReport.php
+++ b/app/Console/Commands/SwpReport.php
@@ -44,11 +44,11 @@ class SwpReport extends Command
             $reportDate = date('Y-m-01');
         }
 
-        $endOfMonth = Carbon::parse($reportDate)->endOfMonth();
+        $endOfMonth = Carbon::parse($reportDate)->endOfMonth()->format('Y-m-d');
 
         $swp['report_date'] = date('F, Y', strtotime($reportDate));
-        $swp['ESWP'] = AwardLog::getAwardLogData(['award' => 'ESWP', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
-        $swp['OSWP'] = AwardLog::getAwardLogData(['award' => 'OSWP', 'start' => $reportDate, 'end' => $endOfMonth->format('Y-m-d')]);
+        $swp['ESWP'] = AwardLog::getAwardLogData(['award' => 'ESWP', 'start' => $reportDate, 'end' => $endOfMonth]);
+        $swp['OSWP'] = AwardLog::getAwardLogData(['award' => 'OSWP', 'start' => $reportDate, 'end' => $endOfMonth]);
 
         \Mail::to(config('awards.SWP-notification.email'))->send(new \App\Mail\swpReport($swp));
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\AddFleetCoPermission::class,
         \App\Console\Commands\UpdatePromotionStatus::class,
         \App\Console\Commands\SwpReport::class,
+        \App\Console\Commands\McamReport::class,
         \App\Console\Commands\SWPCheck::class,
     ];
 

--- a/app/Mail/mcamReport.php
+++ b/app/Mail/mcamReport.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class mcamReport extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * An array of MCAM recipients for the previous month.
+     *
+     * @var array
+     */
+    public $mcamReport;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param array $mcamReport
+     *
+     * @return void
+     */
+    public function __construct(array $mcamReport)
+    {
+        $this->mcamReport = $mcamReport;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from(config('awards.from.address'), config('awards.from.name'))
+            ->subject(config('awards.MCAM-notification.subject'))->markdown('emails.mcamReport');
+    }
+}

--- a/resources/views/emails/mcamReport.blade.php
+++ b/resources/views/emails/mcamReport.blade.php
@@ -1,0 +1,16 @@
+@component('vendor.mail.html.message')
+    The following individuals have qualified for the indicated MCAM for {{$mcamReport['report_date']}}
+
+    @component('mail::table')
+        | Name | Member ID | MCAM Ordinal |
+        |------|:-----------:|:----------:|
+        @if (!empty($mcamReport['MCAM']) || !empty($mcamReport['MCAM']))
+            @foreach($mcamReport['MCAM'] as $line)
+                | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{App\Utility\MedusaUtility::ordinal($line->qty)}}|
+            @endforeach
+        @else
+            No MCAM qualifications for {{$mcamReport['report_date']}}
+        @endif
+    @endcomponent
+
+@endcomponent

--- a/resources/views/emails/mcamReport.blade.php
+++ b/resources/views/emails/mcamReport.blade.php
@@ -2,7 +2,7 @@
     The following individuals have qualified for the indicated MCAM for {{$mcamReport['report_date']}}
 
     @component('mail::table')
-        | Name | Member ID | MCAM Ordinal |
+        | Name | Member ID | Award Number |
         |------|:-----------:|:----------:|
         @if (!empty($mcamReport['MCAM']) || !empty($mcamReport['MCAM']))
             @foreach($mcamReport['MCAM'] as $line)


### PR DESCRIPTION
- Add end date to the SWP report processing.
- Add MCAM report.

Note: The event listener remains so that the MCAM award is computed and added to AwardLog.