### PR TITLE
Fix table formatting in the emails

### DIFF
--- a/resources/views/emails/mcamReport.blade.php
+++ b/resources/views/emails/mcamReport.blade.php
@@ -1,16 +1,16 @@
 @component('vendor.mail.html.message')
     The following individuals have qualified for the indicated MCAM for {{$mcamReport['report_date']}}
 
-    @component('mail::table')
-        | Name | Member ID | Award Number |
-        |------|:-----------:|:----------:|
-        @if (!empty($mcamReport['MCAM']) || !empty($mcamReport['MCAM']))
-            @foreach($mcamReport['MCAM'] as $line)
-                | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{App\Utility\MedusaUtility::ordinal($line->qty)}}|
-            @endforeach
-        @else
-            No MCAM qualifications for {{$mcamReport['report_date']}}
-        @endif
-    @endcomponent
+@component('mail::table')
+    | Name | Member ID | Award Number |
+    |------|:-----------|:----------|
+    @if (!empty($mcamReport['MCAM']) || !empty($mcamReport['MCAM']))
+        @foreach($mcamReport['MCAM'] as $line)
+            | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{App\Utility\MedusaUtility::ordinal($line->qty)}}|
+        @endforeach
+    @else
+        No MCAM qualifications for {{$mcamReport['report_date']}}
+    @endif
+@endcomponent
 
 @endcomponent

--- a/resources/views/emails/swpReport.blade.php
+++ b/resources/views/emails/swpReport.blade.php
@@ -1,19 +1,19 @@
 @component('vendor.mail.html.message')
     The following individuals have qualified for the indicated SWP for {{$swpReport['report_date']}}
 
-    @component('mail::table')
-        | Name | Member ID | SWP Type |
-        |------|:-----------:|:----------:|
-        @if (!empty($swpReport['ESWP']) || !empty($swpReport['OSWP']))
-            @foreach($swpReport['ESWP'] as $line)
-                | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{$line->award}}|
-            @endforeach
-            @foreach($swpReport['OSWP'] as $line)
-                | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{$line->award}}|
-            @endforeach
-        @else
-            No SWP qualifications for {{$swpReport['report_date']}}
-        @endif
-    @endcomponent
+@component('mail::table')
+    | Name | Member ID | SWP Type |
+    |------|:-----------|:----------|
+    @if (!empty($swpReport['ESWP']) || !empty($swpReport['OSWP']))
+        @foreach($swpReport['ESWP'] as $line)
+            | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{$line->award}}|
+        @endforeach
+        @foreach($swpReport['OSWP'] as $line)
+            | {{App\User::getUserByMemberId($line->member_id)->getFullName()}} | {{$line->member_id}} | {{$line->award}}|
+        @endforeach
+    @else
+        No SWP qualifications for {{$swpReport['report_date']}}
+    @endif
+@endcomponent
 
 @endcomponent


### PR DESCRIPTION
- Remove the indention, which is screwing up the markdown table rendering and resulting in a &lt;pre&gt; block with part of the table in it.